### PR TITLE
Define frame bytes in config

### DIFF
--- a/antenna.ino
+++ b/antenna.ino
@@ -21,8 +21,8 @@ void loop()
     digitalWrite(LED_BUILTIN, HIGH); // Optional: visualize block start
 
     // Send Preamble
-    Serial.write(0xAA);
-    Serial.write(0x55);
+    Serial.write(PREAMBLE_BYTE_1);
+    Serial.write(PREAMBLE_BYTE_2);
 
     // Send block size (BUFFER_SIZE * 2 bytes)
     uint16_t blockSize = BUFFER_SIZE * 2;
@@ -40,7 +40,7 @@ void loop()
     }
 
     // Send Stopbyte
-    Serial.write(0xFE);
+    Serial.write(STOP_BYTE);
 
     // Reset for next block
     sampleIndex = 0;

--- a/src/config.h
+++ b/src/config.h
@@ -11,6 +11,10 @@ const int ADC_CHANNEL = 0;            // MCP3008 channel to read (0-7)
 const int BUFFER_SIZE = 256;          // Number of samples per block
 const int TARGET_SAMPLE_RATE = 75000; // 75 kSPS
 
+const uint8_t PREAMBLE_BYTE_1 = 0xAA; // Frame preamble first byte
+const uint8_t PREAMBLE_BYTE_2 = 0x55; // Frame preamble second byte
+const uint8_t STOP_BYTE = 0xFE;       // Frame stop byte
+
 extern uint16_t sampleBuffer[BUFFER_SIZE]; // Buffer to hold samples
 extern volatile bool sampleFlag;           // Flag to indicate buffer is full
 extern volatile uint16_t sampleIndex;      // Current index in the sample buffer


### PR DESCRIPTION
## Summary
- define constants for frame preamble and stop bytes
- use the constants in `antenna.ino`

## Testing
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68465c989b9c8322bc73833bae9ad637