### PR TITLE
Fix block size calculation in antenna.ino

### DIFF
--- a/antenna.ino
+++ b/antenna.ino
@@ -24,8 +24,8 @@ void loop()
     Serial.write(0xAA);
     Serial.write(0x55);
 
-    // Send block size (BUFFER_SIZE * 2 bytes)
-    uint16_t blockSize = BUFFER_SIZE * 2;
+    // Send block size (sizeof(sampleBuffer) bytes)
+    uint16_t blockSize = sizeof(sampleBuffer);
     Serial.write(lowByte(blockSize));
     Serial.write(highByte(blockSize));
 


### PR DESCRIPTION
## Summary
- compute block size using `sizeof(sampleBuffer)`

## Testing
- `make` *(fails: No makefile)*

------
https://chatgpt.com/codex/tasks/task_e_68465ca244d48322a834b980fb9061e4