### PR TITLE
Add CRC16 block integrity check

### DIFF
--- a/antenna.ino
+++ b/antenna.ino
@@ -1,17 +1,18 @@
 #include "src/config.h"
 #include "src/setup.h"
 #include "src/sampleISR.h"
+#include "src/crc16.h"
 
-void sendTimestamp()
+static void getTimestamp(uint8_t *ts)
 {
   DateTime now = rtc.now();
 
-  Serial.write(now.year() - 2000); // YY
-  Serial.write(now.month());       // MM
-  Serial.write(now.day());         // DD
-  Serial.write(now.hour());        // HH
-  Serial.write(now.minute());      // MM
-  Serial.write(now.second());      // SS
+  ts[0] = now.year() - 2000; // YY
+  ts[1] = now.month();       // MM
+  ts[2] = now.day();         // DD
+  ts[3] = now.hour();        // HH
+  ts[4] = now.minute();      // MM
+  ts[5] = now.second();      // SS
 }
 
 void loop()
@@ -20,18 +21,43 @@ void loop()
   {
     digitalWrite(LED_BUILTIN, HIGH); // Optional: visualize block start
 
+    uint16_t crc = 0xFFFF;
+
+    uint8_t ts[6];
+    getTimestamp(ts);
+
+    // Compute CRC over header
+    crc = crc16_update(crc, PREAMBLE_BYTE_1);
+    crc = crc16_update(crc, PREAMBLE_BYTE_2);
+
+    uint16_t blockSize = bufferSize * sizeof(sampleBuffer[0]);
+    crc = crc16_update(crc, lowByte(blockSize));
+    crc = crc16_update(crc, highByte(blockSize));
+
+    for (uint8_t i = 0; i < sizeof(ts); ++i)
+    {
+      crc = crc16_update(crc, ts[i]);
+    }
+
+    for (uint16_t i = 0; i < bufferSize; i++)
+    {
+      crc = crc16_update(crc, lowByte(sampleBuffer[i]));
+      crc = crc16_update(crc, highByte(sampleBuffer[i]));
+    }
+
     // Send Preamble
     Serial.write(PREAMBLE_BYTE_1);
     Serial.write(PREAMBLE_BYTE_2);
 
-
-    // Send block size (sizeof(sampleBuffer) bytes)
-    uint16_t blockSize = sizeof(sampleBuffer);
+    // Send block size
     Serial.write(lowByte(blockSize));
     Serial.write(highByte(blockSize));
 
     // Send timestamp
-    sendTimestamp();
+    for (uint8_t i = 0; i < sizeof(ts); ++i)
+    {
+      Serial.write(ts[i]);
+    }
 
     // Send sample data
     for (uint16_t i = 0; i < bufferSize; i++)
@@ -39,6 +65,10 @@ void loop()
       Serial.write(lowByte(sampleBuffer[i]));
       Serial.write(highByte(sampleBuffer[i]));
     }
+
+    // Send CRC
+    Serial.write(lowByte(crc));
+    Serial.write(highByte(crc));
 
     // Send Stopbyte
     Serial.write(STOP_BYTE);

--- a/src/crc16.cpp
+++ b/src/crc16.cpp
@@ -1,0 +1,14 @@
+#include "crc16.h"
+
+uint16_t crc16_update(uint16_t crc, uint8_t data)
+{
+    crc ^= data;
+    for (uint8_t i = 0; i < 8; ++i)
+    {
+        if (crc & 1)
+            crc = (crc >> 1) ^ 0xA001;
+        else
+            crc >>= 1;
+    }
+    return crc;
+}

--- a/src/crc16.h
+++ b/src/crc16.h
@@ -1,0 +1,8 @@
+#ifndef CRC16_H
+#define CRC16_H
+
+#include <Arduino.h>
+
+uint16_t crc16_update(uint16_t crc, uint8_t data);
+
+#endif // CRC16_H

--- a/tools/verify_crc.py
+++ b/tools/verify_crc.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import sys
+
+POLY = 0xA001
+
+def crc16(data: bytes, crc: int = 0xFFFF) -> int:
+    for b in data:
+        crc ^= b
+        for _ in range(8):
+            if crc & 1:
+                crc = (crc >> 1) ^ POLY
+            else:
+                crc >>= 1
+    return crc & 0xFFFF
+
+def main(path: str):
+    with open(path, 'rb') as f:
+        buf = f.read()
+    if len(buf) < 3:
+        print('File too short')
+        return 1
+    data = buf[:-3]
+    crc_expected = buf[-3] | (buf[-2] << 8)
+    stop_byte = buf[-1]
+    crc_calc = crc16(data)
+    print('CRC expected:', hex(crc_expected))
+    print('CRC calculated:', hex(crc_calc))
+    print('Stop byte:', hex(stop_byte))
+    if crc_expected == crc_calc:
+        print('CRC OK')
+    else:
+        print('CRC MISMATCH')
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print('Usage: verify_crc.py <binary_file>')
+        sys.exit(1)
+    main(sys.argv[1])


### PR DESCRIPTION
## Summary
- implement a CRC16 function for Arduino
- compute CRC over the entire block before transmission
- append CRC bytes before the stop byte
- add a small Python script that verifies the CRC

## Testing
- `python3 -m py_compile tools/verify_crc.py`
- `g++ -std=c++11 -fsyntax-only src/crc16.cpp` *(fails: `Arduino.h: No such file or directory`)*


------
https://chatgpt.com/codex/tasks/task_e_68465f8c77f083229001720736589a2e